### PR TITLE
Fix is_acceptable bug

### DIFF
--- a/src/gale_shapley/person.py
+++ b/src/gale_shapley/person.py
@@ -43,7 +43,9 @@ class Person:
         Returns:
             bool: Returns True if person is acceptable to self, False otherwise
         """
-        if self and person in self.preferences:
+        if self == person:
+            return True
+        if person in self.preferences:
             return self.preferences.index(person) <= self.preferences.index(self)
         raise ValueError(f"Either {self} or {person} is not in preferences.")
 

--- a/tests/person_test.py
+++ b/tests/person_test.py
@@ -65,6 +65,20 @@ class TestPerson:
         assert self.w_2.is_acceptable(self.m_1)
         assert self.w_2.is_acceptable(self.w_2)
 
+    def test_is_acceptable_invalid_preferences(self) -> None:
+        """Test that is_acceptable raises ValueError when preferences are invalid."""
+
+        proposer = Proposer("x", "man")
+        responder = Responder("y", "woman")
+        proposer.preferences = (responder,)
+
+        with pytest.raises(ValueError):
+            proposer.is_acceptable(responder)
+
+        responder.preferences = (proposer,)
+        with pytest.raises(ValueError):
+            responder.is_acceptable(proposer)
+
     def test_is_matched(self) -> None:
         """Test that is_matched property works correctly."""
         # Initially no one is matched


### PR DESCRIPTION
## Summary
- fix the membership check in `is_acceptable`
- add a regression test for invalid preferences
- refine `is_acceptable` logic

## Testing
- `PYTHONPATH=src pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6853d4024ccc832a8af6e24fbe966e45